### PR TITLE
feat: Adds support for single wireless device (web too).

### DIFF
--- a/packages/core/src/__tests__/test.spec.ts
+++ b/packages/core/src/__tests__/test.spec.ts
@@ -16,6 +16,7 @@ async function openMockDevice(path: string): Promise<XencelabsQuickKeys> {
 	const mockedFn = ((device as any).sendReports = jest.fn())
 
 	const result = await XencelabsQuickKeysDevice.create(device)
+	result['getDeviceId'](Buffer.of(0xeb, 0x4f, 0x49, 0xbd, 0xd7, 0xfa), 0)
 
 	expect(mockedFn).toHaveBeenCalledTimes(1)
 	device.sendReports = oldFn


### PR DESCRIPTION
This is really just a sample, not really meant to be merged in, but it does fix #1 and allow WebHID to work wirelessly (once you press a button/spin the wheel).

In a real app, the best approach would be to persist/restore a specific device, so I don't have to hit it once every time it connects. This wouldn't solve that, instead it would require a greater change to the API (which you've mentioned in the issue) so I will leave that up to you.